### PR TITLE
Propose to update the defaults in the template configuration

### DIFF
--- a/kedro_sagemaker/config.py
+++ b/kedro_sagemaker/config.py
@@ -59,10 +59,10 @@ aws:
   sagemaker:
     # (optional) mapping between kedro pipeline names (keys) and SageMaker pipeline names
     # Note that SageMaker does not support underscores in pipeline names.
-    # Here you can map for example add `__default__: "my-pipeline"`
-    # to make the `__default__` Kedro pipeline appear as `my-pipeline` in SageMaker UI
+    # Here you can map for example add `__default__: "kedro-sagemaker-default-pipeline"`
+    # to make the `__default__` Kedro pipeline appear as `kedro-sagemaker-default-pipeline` in SageMaker UI
     pipeline_names_mapping:
-      __default__: "my-pipeline"
+      __default__: "kedro-sagemaker-default-pipeline"
 docker:
   image: "{docker_image}"
   working_directory: /home/kedro

--- a/kedro_sagemaker/config.py
+++ b/kedro_sagemaker/config.py
@@ -52,7 +52,7 @@ aws:
   resources:
     __default__:
       instance_count: 1
-      instance_type: ml.m5.large
+      instance_type: ml.t3.medium
       timeout_seconds: 86400
       security_group_ids: null
       subnets: null
@@ -62,7 +62,7 @@ aws:
     # Here you can map for example add `__default__: "my-pipeline"`
     # to make the `__default__` Kedro pipeline appear as `my-pipeline` in SageMaker UI
     pipeline_names_mapping:
-      kedro_pipeline_name: "sagemaker-pipeline-name"
+      __default__: "my-pipeline"
 docker:
   image: "{docker_image}"
   working_directory: /home/kedro

--- a/kedro_sagemaker/generator.py
+++ b/kedro_sagemaker/generator.py
@@ -119,7 +119,7 @@ class KedroSageMakerGenerator:
 
     def _get_sagemaker_pipeline_name(self) -> str:
         return (self.config.aws.sagemaker.pipeline_names_mapping or {}).get(
-            self.pipeline_name, "kedro-sagemaker-pipeline"
+            self.pipeline_name, "kedro-sagemaker-default-pipeline"
         )
 
     def _get_default_resources(self) -> ResourceConfig:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -50,7 +50,7 @@ def test_should_generate_pipeline_with_processing_steps(context_mock, no_mlflow)
 
     # then
     assert isinstance(pipeline.sagemaker_session, pipeline_context.PipelineSession)
-    assert pipeline.name == "kedro-sagemaker-pipeline"  # a default one
+    assert pipeline.name == "kedro-sagemaker-default-pipeline"  # a default one
     assert len(pipeline.parameters) == 0
     assert len(pipeline.steps) == 2
 


### PR DESCRIPTION
Hi, thank you for creating this plugin. I have tried to play around with it and successfully run my pipeline on SageMaker. 

# Context
This is mainly from the perspective of someone who just wants to try out the plugin and see how it works. I try to document the challenges that I encountered and I hope this will smooth out the onboarding process a bit.

# Proposed Changes
* Update the default so it will work without any changes
  *  Change machine type to `ml.t3.medium`, this is supported by the free-tier while the `ml.t5.large`.
  * `__default__` should be made the default since the current template wouldn't work. I know it's mentioned in the comment but it is nicer to have a ready-to-run default.
  * There are not many docs about the setup for AWS, I know it's not exactly the responsibility of this plugin, but I think the user will appreciate some guide on setting up S3 + IAM role + ECR repository + SageMaker + SageMaker Studio profile etc.
  * Populate a link to the corresponding experiment automatically - I am not sure if is this possible, but when I first run the pipeline I struggle to see my pipeline until later I find out I need to create a profile and check my pipeline in Studio. It would be nice if there is a clickable link in the terminal.

Thanks for creating the plugin, the video is also quite useful as it provides extra instructions that aren't covered in the documentation.
