### PR TITLE
Fix for compatibility with Kedro 0.18.4 onwards

### DIFF
--- a/kedro_sagemaker/cli_functions.py
+++ b/kedro_sagemaker/cli_functions.py
@@ -68,7 +68,7 @@ def docker_autobuild(auto_build, click_context, image, mgr, yes):
         if not yes and not click.confirm("Continue?", default=True):
             click_context.exit(1)
 
-        if (rv := docker_build(str(mgr.context.project_path), image)) != 0:
+        if (rv := docker_build(str(mgr.context.project_path), image, str(mgr.plugin_config.docker.platforms))) != 0:
             click_context.exit(rv)
         if (rv := docker_push(image)) != 0:
             click_context.exit(rv)

--- a/kedro_sagemaker/config.py
+++ b/kedro_sagemaker/config.py
@@ -25,6 +25,7 @@ class SageMakerConfig(BaseModel):
 class DockerConfig(BaseModel):
     image: str
     working_directory: str = "/home/kedro"
+    platforms: str
 
 
 class AwsConfig(BaseModel):
@@ -66,6 +67,7 @@ aws:
 docker:
   image: "{docker_image}"
   working_directory: /home/kedro
+  platforms: "linux/amd64"
 """.strip()
 
 # This auto-validates the template above during import

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -118,7 +118,7 @@ def test_docker_build(exit_code):
     with patch(
         "subprocess.run", return_value=Mock(returncode=exit_code)
     ) as subprocess_run:
-        result = docker_build(".", "my_image:latest")
+        result = docker_build(".", "my_image:latest","platforms")
         assert exit_code == result, "Invalid exit code"
         subprocess_run.assert_called_once()
 


### PR DESCRIPTION
Updates to allow integration with kedro 0.18.4 > onwards which uses OmegaConfigLoader which replaced the legacy ConfigLoader and TemplatedConfigLoader previously used. Updates also allow for backwards integration for versions of kedro <= 0.18.4.

Updates also added user flexibility for choice of docker image platform architecture which allows for multi-architecture docker images.

As a result of the codebase changes updates to the affected unit tests were made.

This is my first PR for a public codebase so any feedback or comments is appreciated :) 